### PR TITLE
Revert "BRN-29: remove credential requirements for downloading an app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,16 @@
 > using it.
 
 ## Install the svydovets-bring-framework:
-1. Add maven repository to your build.gradle.
+1. Add maven repository to your build.gradle. You need your github username and github packages read token.
 ```
 repositories {
   mavenCentral()
   maven {
     url = uri("https://maven.pkg.github.com/maingroon/svydovets-bring")
+      credentials {
+        username = System.getenv("GH_USER")
+        password = System.getenv("GH_PACKAGES_READ_TOKEN")
+      }
    }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,34 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+javadoc {
+    source = sourceSets.main.allJava
+    include 'src/main/java'
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier.set("sources")
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set("javadoc")
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
 publishing {
     publications {
         javaLibrary(MavenPublication) {
             from project.components.java
             groupId = project.group
+
+            artifact sourcesJar
+            artifact javadocJar
         }
     }
     repositories {


### PR DESCRIPTION
This reverts commit d63afc4a079a4453b098246485692e3c8df3b68a because credentials are must have to install the bring framework